### PR TITLE
allow handlers to return a promise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 components/
 node_modules/
+*.swp

--- a/lib/MockXMLHttpRequest.js
+++ b/lib/MockXMLHttpRequest.js
@@ -174,6 +174,11 @@ MockXMLHttpRequest.prototype.send = function(data) {
         self.trigger('error');
 
       }
+    }).catch(function(errorResponse){
+      self.status     = errorResponse.status();
+      self.response   = errorResponse.body();
+      self.readyState = MockXMLHttpRequest.STATE_DONE;
+      self.trigger('error');
     });
 
   }, 0);

--- a/lib/MockXMLHttpRequest.js
+++ b/lib/MockXMLHttpRequest.js
@@ -138,40 +138,43 @@ MockXMLHttpRequest.prototype.send = function(data) {
 
     var response = MockXMLHttpRequest.handle(new MockRequest(self));
 
-    if (response && response instanceof MockResponse) {
+    Promise.resolve(response).then(function(response){
 
-      var timeout = response.timeout();
+      if (response && response instanceof MockResponse) {
 
-      if (timeout) {
+        var timeout = response.timeout();
 
-        //trigger a timeout event because the request timed out - wait for the timeout time because many libs like jquery and superagent use setTimeout to detect the error type
-        self._sendTimeout = setTimeout(function() {
-          self.readyState = MockXMLHttpRequest.STATE_DONE;
-          self.trigger('timeout');
-        }, typeof(timeout) === 'number' ? timeout : self.timeout+1);
+        if (timeout) {
+
+          //trigger a timeout event because the request timed out - wait for the timeout time because many libs like jquery and superagent use setTimeout to detect the error type
+          self._sendTimeout = setTimeout(function() {
+            self.readyState = MockXMLHttpRequest.STATE_DONE;
+            self.trigger('timeout');
+          }, typeof(timeout) === 'number' ? timeout : self.timeout+1);
+
+        } else {
+
+          //map the response to the XHR object
+          self.status             = response.status();
+          self._responseHeaders   = response.headers();
+          self.responseType       = 'text';
+          self.response           = response.body();
+          self.responseText       = response.body(); //TODO: detect an object and return JSON, detect XML and return XML
+          self.readyState         = MockXMLHttpRequest.STATE_DONE;
+
+          //trigger a load event because the request was received
+          self.trigger('load');
+
+        }
 
       } else {
 
-        //map the response to the XHR object
-        self.status             = response.status();
-        self._responseHeaders   = response.headers();
-        self.responseType       = 'text';
-        self.response           = response.body();
-        self.responseText       = response.body(); //TODO: detect an object and return JSON, detect XML and return XML
-        self.readyState         = MockXMLHttpRequest.STATE_DONE;
-
-        //trigger a load event because the request was received
-        self.trigger('load');
+        //trigger an error because the request was not handled
+        self.readyState = MockXMLHttpRequest.STATE_DONE;
+        self.trigger('error');
 
       }
-
-    } else {
-
-      //trigger an error because the request was not handled
-      self.readyState = MockXMLHttpRequest.STATE_DONE;
-      self.trigger('error');
-
-    }
+    });
 
   }, 0);
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "browserify": "^11.0.1",
+    "lie": "^3.0.2",
     "mochify": "^2.13.0",
     "superagent": "^1.3.0"
   },

--- a/test/MockXMLHttpRequest.js
+++ b/test/MockXMLHttpRequest.js
@@ -1,3 +1,4 @@
+require('lie/polyfill');
 var assert              = require('assert');
 var MockXMLHttpRequest  = require('../lib/MockXMLHttpRequest');
 
@@ -182,6 +183,28 @@ describe('MockXMLHttpRequest', function() {
 
     });
 
+  });
+
+  describe('async response', function() {
+    it('when a response returns a promise wait for it to resolve', function(done){
+      MockXMLHttpRequest.addHandler(function(req, res) {
+        return new Promise(function(success){
+          success(
+            res
+              .header('Content-Type', 'application/json')
+              .header('X-Powered-By', 'SecretSauce')
+          );
+        });
+      })
+
+      var xhr = new MockXMLHttpRequest();
+      xhr.open('/');
+      xhr.onload = function() {
+        assert.equal(xhr.getAllResponseHeaders(), 'content-type: application/json\r\nx-powered-by: SecretSauce\r\n');
+        done();
+      };
+      xhr.send();
+    });
   });
 
 });

--- a/test/MockXMLHttpRequest.js
+++ b/test/MockXMLHttpRequest.js
@@ -205,6 +205,28 @@ describe('MockXMLHttpRequest', function() {
       };
       xhr.send();
     });
+
+    it('when a response returns a promise that is rejected', function(done){
+      MockXMLHttpRequest.addHandler(function(req, res) {
+        return new Promise(function(success, failure){
+          failure(
+            res
+              .status(500)
+              .body('An error occured on the server')
+          );
+        });
+      })
+
+      var xhr = new MockXMLHttpRequest();
+      xhr.open('/');
+      xhr.onerror = function() {
+        assert.equal(xhr.status, 500);
+        assert.equal(xhr.response, 'An error occured on the server');
+
+        done();
+      };
+      xhr.send();
+    });
   });
 
 });


### PR DESCRIPTION
this change allows you to return a promise from a handler.
this is useful when you don't want to respond to the request immediately.

For example you may want to test that some loading code is executed when the response does not return complete after 200ms (one of my use cases)
