### PR TITLE
Improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
+.vscode
 build/
 components/
 node_modules/
+*.log

--- a/README.md
+++ b/README.md
@@ -74,27 +74,31 @@ Replace the global `XMLHttpRequest` object with the `MockXMLHttpRequest`.
 
 Restore the global `XMLHttpRequest` object to its original state.
 
-#### .get(url, fn)
+#### .reset()
+
+Forget all the request handlers.
+
+#### .get(url | regex, fn)
 
 Register a factory function to create mock responses for each GET request to a specific URL.
 
-#### .post(url, fn)
+#### .post(url | regex, fn)
 
 Register a factory function to create mock responses for each POST request to a specific URL.
 
-#### .put(url, fn)
+#### .put(url | regex, fn)
 
 Register a factory function to create mock responses for each PUT request to a specific URL.
 
-#### .patch(url, fn)
+#### .patch(url | regex, fn)
 
 Register a factory function to create mock responses for each PATCH request to a specific URL.
 
-#### .delete(url, fn)
+#### .delete(url | regex, fn)
 
 Register a factory function to create mock responses for each DELETE request to a specific URL.
 
-#### .mock(method, url, fn)
+#### .mock(method, url | regex, fn)
 
 Register a factory function to create mock responses for each request to a specific URL.
 
@@ -113,6 +117,10 @@ Get the request method.
 #### .url() : string
 
 Get the request URL.
+
+#### .query() : object
+
+Get the parsed query part of the request URL.
 
 #### .header(name : string) : string
 
@@ -173,6 +181,11 @@ Set whether the response will trigger a time out. `timeout` defaults to the valu
 Trigger progress event. Pass in loaded size, total size and if event is lengthComputable.
 
 ## Change log
+- added support for regexes instead of URLs in all the mock methods
+- added the `.query()` method to the request object
+- added the `.reset()` method to `mock` and `MockXMLHttpRequest`
+- added `withCredentials` to the mocked XHR objects (used by some libraries to test for "real" XHR support)
+
 ### 1.7.0
 
 - added support for `addEventListener` ([#15](https://github.com/jameslnewell/xhr-mock/pull/15))

--- a/component.json
+++ b/component.json
@@ -1,15 +1,15 @@
 {
   "name": "xhr-mock",
   "scripts": [
-	"index.js",
-	"lib/MockRequest.js",
-	"lib/MockResponse.js",
-	"lib/MockXMLHttpRequest.js"
+  "index.js",
+  "lib/MockRequest.js",
+  "lib/MockResponse.js",
+  "lib/MockXMLHttpRequest.js"
   ],
   "development": {
-	  "dependencies": {
-		  "component/assert": "*",
-		  "visionmedia/superagent": "~1.2.0"
-	  }
+    "dependencies": {
+      "component/assert": "*",
+      "visionmedia/superagent": "~1.2.0"
+    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -16,8 +16,7 @@ module.exports = {
 	 */
 	setup: function() {
 		window.XMLHttpRequest = mock;
-		MockXMLHttpRequest.handlers = [];
-		return this;
+		return this.reset();
 	},
 
 	/**
@@ -25,9 +24,8 @@ module.exports = {
 	 * @returns {exports}
 	 */
 	teardown: function() {
-		MockXMLHttpRequest.handlers = [];
 		window.XMLHttpRequest = real;
-		return this;
+    return this.reset();
 	},
 
 	/**
@@ -35,7 +33,7 @@ module.exports = {
 	 * @returns {exports}
 	 */
 	reset: function() {
-		MockXMLHttpRequest.handlers = [];
+		MockXMLHttpRequest.reset();
 		return this;
 	},
 

--- a/index.js
+++ b/index.js
@@ -38,10 +38,18 @@ module.exports = {
 	 * @returns {exports}
 	 */
 	mock: function(method, url, fn) {
-		var handler;
+		var handler, matcher;
 		if (arguments.length === 3) {
+			matcher = function(req) {
+				if (req.method() !== method) return false;
+				var reqUrl = req.url();
+				// allow regexp urls matcher
+				if (url instanceof RegExp) return url.test(reqUrl);
+				// otherwise assume the url is a string
+				return url === reqUrl;
+			}
 			handler = function(req, res) {
-				if (req.method() === method && req.url() === url) {
+				if (matcher(req)) {
 					return fn(req, res);
 				}
 				return false;

--- a/index.js
+++ b/index.js
@@ -31,6 +31,15 @@ module.exports = {
 	},
 
 	/**
+	 * Remove any handlers
+	 * @returns {exports}
+	 */
+	reset: function() {
+		MockXMLHttpRequest.handlers = [];
+		return this;
+	},
+
+	/**
 	 * Mock a request
 	 * @param   {string}    [method]
 	 * @param   {string}    [url]

--- a/index.js
+++ b/index.js
@@ -8,116 +8,116 @@ var mock                = MockXMLHttpRequest;
  */
 module.exports = {
 
-	XMLHttpRequest: MockXMLHttpRequest,
+  XMLHttpRequest: MockXMLHttpRequest,
 
-	/**
-	 * Replace the native XHR with the mocked XHR
-	 * @returns {exports}
-	 */
-	setup: function() {
-		window.XMLHttpRequest = mock;
-		return this.reset();
-	},
-
-	/**
-	 * Replace the mocked XHR with the native XHR and remove any handlers
-	 * @returns {exports}
-	 */
-	teardown: function() {
-		window.XMLHttpRequest = real;
+  /**
+   * Replace the native XHR with the mocked XHR
+   * @returns {exports}
+   */
+  setup: function() {
+    window.XMLHttpRequest = mock;
     return this.reset();
-	},
+  },
 
-	/**
-	 * Remove any handlers
-	 * @returns {exports}
-	 */
-	reset: function() {
-		MockXMLHttpRequest.reset();
-		return this;
-	},
+  /**
+   * Replace the mocked XHR with the native XHR and remove any handlers
+   * @returns {exports}
+   */
+  teardown: function() {
+    window.XMLHttpRequest = real;
+    return this.reset();
+  },
 
-	/**
-	 * Mock a request
-	 * @param   {string}    [method]
-	 * @param   {string}    [url]
-	 * @param   {Function}  fn
-	 * @returns {exports}
-	 */
-	mock: function(method, url, fn) {
-		var handler, matcher;
-		if (arguments.length === 3) {
-			matcher = function(req) {
-				if (req.method() !== method) return false;
-				var reqUrl = req.url();
-				// allow regexp urls matcher
-				if (url instanceof RegExp) return url.test(reqUrl);
-				// otherwise assume the url is a string
-				return url === reqUrl;
-			}
-			handler = function(req, res) {
-				if (matcher(req)) {
-					return fn(req, res);
-				}
-				return false;
-			};
-		} else {
-			handler = method;
-		}
+  /**
+   * Remove any handlers
+   * @returns {exports}
+   */
+  reset: function() {
+    MockXMLHttpRequest.reset();
+    return this;
+  },
 
-		MockXMLHttpRequest.addHandler(handler);
+  /**
+   * Mock a request
+   * @param   {string}    [method]
+   * @param   {string}    [url]
+   * @param   {Function}  fn
+   * @returns {exports}
+   */
+  mock: function(method, url, fn) {
+    var handler, matcher;
+    if (arguments.length === 3) {
+      matcher = function(req) {
+        if (req.method() !== method) return false;
+        var reqUrl = req.url();
+        // allow regexp urls matcher
+        if (url instanceof RegExp) return url.test(reqUrl);
+        // otherwise assume the url is a string
+        return url === reqUrl;
+      }
+      handler = function(req, res) {
+        if (matcher(req)) {
+          return fn(req, res);
+        }
+        return false;
+      };
+    } else {
+      handler = method;
+    }
 
-		return this;
-	},
+    MockXMLHttpRequest.addHandler(handler);
 
-	/**
-	 * Mock a GET request
-	 * @param   {String}    url
-	 * @param   {Function}  fn
-	 * @returns {exports}
-	 */
-	get: function(url, fn) {
-		return this.mock('GET', url, fn);
-	},
+    return this;
+  },
 
-	/**
-	 * Mock a POST request
-	 * @param   {String}    url
-	 * @param   {Function}  fn
-	 * @returns {exports}
-	 */
-	post: function(url, fn) {
-		return this.mock('POST', url, fn);
-	},
+  /**
+   * Mock a GET request
+   * @param   {String}    url
+   * @param   {Function}  fn
+   * @returns {exports}
+   */
+  get: function(url, fn) {
+    return this.mock('GET', url, fn);
+  },
 
-	/**
-	 * Mock a PUT request
-	 * @param   {String}    url
-	 * @param   {Function}  fn
-	 * @returns {exports}
-	 */
-	put: function(url, fn) {
-		return this.mock('PUT', url, fn);
-	},
+  /**
+   * Mock a POST request
+   * @param   {String}    url
+   * @param   {Function}  fn
+   * @returns {exports}
+   */
+  post: function(url, fn) {
+    return this.mock('POST', url, fn);
+  },
 
-	/**
-	 * Mock a PATCH request
-	 * @param   {String}    url
-	 * @param   {Function}  fn
-	 * @returns {exports}
-	 */
-	patch: function(url, fn) {
-		return this.mock('PATCH', url, fn);
-	},
+  /**
+   * Mock a PUT request
+   * @param   {String}    url
+   * @param   {Function}  fn
+   * @returns {exports}
+   */
+  put: function(url, fn) {
+    return this.mock('PUT', url, fn);
+  },
 
-	/**
-	 * Mock a DELETE request
-	 * @param   {String}    url
-	 * @param   {Function}  fn
-	 * @returns {exports}
-	 */
-	delete: function(url, fn) {
-		return this.mock('DELETE', url, fn);
-	}
+  /**
+   * Mock a PATCH request
+   * @param   {String}    url
+   * @param   {Function}  fn
+   * @returns {exports}
+   */
+  patch: function(url, fn) {
+    return this.mock('PATCH', url, fn);
+  },
+
+  /**
+   * Mock a DELETE request
+   * @param   {String}    url
+   * @param   {Function}  fn
+   * @returns {exports}
+   */
+  delete: function(url, fn) {
+    return this.mock('DELETE', url, fn);
+  }
 
 };

--- a/lib/MockRequest.js
+++ b/lib/MockRequest.js
@@ -1,3 +1,4 @@
+var URL = require('url-parse');
 
 /**
  * The mocked request data
@@ -27,6 +28,15 @@ MockRequest.prototype.method = function() {
 MockRequest.prototype.url = function() {
   return this._url;
 };
+
+/**
+ * Get/set the parsed URL query
+ * @returns {Object}
+ */
+MockRequest.prototype.query = function() {
+  var url = new URL(this._url, true);
+  return url.query;
+}
 
 /**
  * Get/set a HTTP header

--- a/lib/MockXMLHttpRequest.js
+++ b/lib/MockXMLHttpRequest.js
@@ -40,6 +40,13 @@ MockXMLHttpRequest.removeHandler = function(fn) {
 };
 
 /**
+ * Remove all request handlers
+ */
+MockXMLHttpRequest.reset = function() {
+  MockXMLHttpRequest.handlers = [];
+}
+
+/**
  * Handle a request
  * @param   {MockRequest} request
  * @returns {MockResponse|null}

--- a/lib/MockXMLHttpRequest.js
+++ b/lib/MockXMLHttpRequest.js
@@ -68,6 +68,9 @@ function MockXMLHttpRequest() {
   this.reset();
   this._eventListeners = [];
   this.timeout = 0;
+  // some libraries (like Mixpanel) use the presence of this field to check if XHR is properly supported
+  // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials
+  this.withCredentials = false;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "url": "git://github.com/jameslnewell/xhr-mock.git"
   },
   "dependencies": {
-    "global": "^4.3.0"
+    "global": "^4.3.0",
+    "url-parse": "^1.1.7"
   },
   "devDependencies": {
     "browserify": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "global": "^4.3.0"
   },
   "devDependencies": {
-    "browserify": "^11.0.1",
+    "browserify": "^14.0.0",
     "mochify": "^2.13.0",
-    "superagent": "^1.3.0"
+    "superagent": "^3.4.1"
   },
   "scripts": {
     "test": "mochify",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "test": "mochify",
-    "example.build": "mkdir build && browserify -r superagent -r ./index.js:xhr-mock -o build/build.js"
+    "example.build": "mkdir -p build && browserify -r superagent -r ./index.js:xhr-mock -o build/build.js"
   },
   "license": "MIT"
 }

--- a/test/MockRequest.js
+++ b/test/MockRequest.js
@@ -1,5 +1,12 @@
-var assert        = require('assert');
-var MockRequest   = require('../lib/MockResponse');
+var assert               = require('assert');
+var MockXMLHttpRequest   = require('../lib/MockXMLHttpRequest');
+var MockRequest          = require('../lib/MockRequest');
 
 describe('MockRequest', function() {
+  it('should parse the query', function() {
+    var xhr = new MockXMLHttpRequest();
+    xhr.open('GET', 'https://example.com/path?a=1&b=2');
+    var req = new MockRequest(xhr);
+    assert.deepEqual(req.query(), { a: 1, b: 2});
+  });
 });

--- a/test/MockXMLHttpRequest.js
+++ b/test/MockXMLHttpRequest.js
@@ -4,11 +4,11 @@ var MockXMLHttpRequest  = require('../lib/MockXMLHttpRequest');
 describe('MockXMLHttpRequest', function() {
 
   beforeEach(function() {
-    MockXMLHttpRequest.handlers = [];
+    MockXMLHttpRequest.reset();
   });
 
   afterEach(function() {
-    MockXMLHttpRequest.handlers = [];
+    MockXMLHttpRequest.reset();
   });
 
   describe('.setRequestHeader()', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -29,4 +29,73 @@ describe('xhr-mock', function() {
 
 	});
 
+	describe('.mock()', function() {
+		it('should allow registering the handler', function(done) {
+			mock.setup();
+
+			mock.mock(function(req, res) {
+				return res
+					.status(200)
+					.body('OK')
+				;
+			});
+
+			var xhr = new XMLHttpRequest();
+			xhr.open('GET', '/');
+			xhr.onload = function() {
+				assert.equal(xhr.responseText, 'OK');
+				mock.teardown();
+				done();
+			};
+			xhr.send();
+		})
+		
+		it('should allow registering a specific URL handler', function(done) {
+			mock.setup();
+
+			mock.mock('GET', '/a', function(req, res) {
+				return res
+					.status(200)
+					.body('A')
+				;
+			});
+			
+			mock.mock('GET', '/b', function(req, res) {
+				return res
+					.status(200)
+					.body('B')
+				;
+			});
+
+			var xhr = new XMLHttpRequest();
+			xhr.open('GET', '/a');
+			xhr.onload = function() {
+				assert.equal(xhr.responseText, 'A');
+				mock.teardown();
+				done();
+			};
+			xhr.send();
+		})
+		
+		it('should allow registering a handler with URL regexp', function(done) {
+			mock.setup();
+
+			mock.mock('POST', /\/a\/\d+/, function(req, res) {
+				return res
+					.status(200)
+					.body(req.url().split('/')[2])
+				;
+			});
+
+			var xhr = new XMLHttpRequest();
+			xhr.open('POST', '/a/123');
+			xhr.onload = function() {
+				assert.equal(xhr.responseText, '123');
+				mock.teardown();
+				done();
+			};
+			xhr.send();
+		})
+	});
+
 });

--- a/test/index.js
+++ b/test/index.js
@@ -4,98 +4,98 @@ var mock    = require('..');
 
 describe('xhr-mock', function() {
 
-	describe('.setup() and teardown()', function() {
+  describe('.setup() and teardown()', function() {
 
-		it('should setup and teardown the mock XMLHttpRequest class', function() {
+    it('should setup and teardown the mock XMLHttpRequest class', function() {
 
-			var xhr = window.XMLHttpRequest;
-			mock.setup();
-			assert.notEqual(window.XMLHttpRequest, xhr);
-			mock.teardown();
-			assert.equal(window.XMLHttpRequest, xhr);
+      var xhr = window.XMLHttpRequest;
+      mock.setup();
+      assert.notEqual(window.XMLHttpRequest, xhr);
+      mock.teardown();
+      assert.equal(window.XMLHttpRequest, xhr);
 
-		});
+    });
 
-		it('should remove any handlers', function() {
+    it('should remove any handlers', function() {
 
-			mock.get('http://www.google.com/', function() {});
-			mock.setup();
-			assert.equal(mock.XMLHttpRequest.handlers.length, 0);
-			mock.get('http://www.google.com/', function() {});
-			mock.teardown();
-			assert.equal(mock.XMLHttpRequest.handlers.length, 0);
+      mock.get('http://www.google.com/', function() {});
+      mock.setup();
+      assert.equal(mock.XMLHttpRequest.handlers.length, 0);
+      mock.get('http://www.google.com/', function() {});
+      mock.teardown();
+      assert.equal(mock.XMLHttpRequest.handlers.length, 0);
 
-		});
+    });
 
-	});
+  });
 
-	describe('.mock()', function() {
-		it('should allow registering the handler', function(done) {
-			mock.setup();
+  describe('.mock()', function() {
+    it('should allow registering the handler', function(done) {
+      mock.setup();
 
-			mock.mock(function(req, res) {
-				return res
-					.status(200)
-					.body('OK')
-				;
-			});
+      mock.mock(function(req, res) {
+        return res
+          .status(200)
+          .body('OK')
+        ;
+      });
 
-			var xhr = new XMLHttpRequest();
-			xhr.open('GET', '/');
-			xhr.onload = function() {
-				assert.equal(xhr.responseText, 'OK');
-				mock.teardown();
-				done();
-			};
-			xhr.send();
-		})
-		
-		it('should allow registering a specific URL handler', function(done) {
-			mock.setup();
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', '/');
+      xhr.onload = function() {
+        assert.equal(xhr.responseText, 'OK');
+        mock.teardown();
+        done();
+      };
+      xhr.send();
+    })
 
-			mock.mock('GET', '/a', function(req, res) {
-				return res
-					.status(200)
-					.body('A')
-				;
-			});
-			
-			mock.mock('GET', '/b', function(req, res) {
-				return res
-					.status(200)
-					.body('B')
-				;
-			});
+    it('should allow registering a specific URL handler', function(done) {
+      mock.setup();
 
-			var xhr = new XMLHttpRequest();
-			xhr.open('GET', '/a');
-			xhr.onload = function() {
-				assert.equal(xhr.responseText, 'A');
-				mock.teardown();
-				done();
-			};
-			xhr.send();
-		})
-		
-		it('should allow registering a handler with URL regexp', function(done) {
-			mock.setup();
+      mock.mock('GET', '/a', function(req, res) {
+        return res
+          .status(200)
+          .body('A')
+        ;
+      });
 
-			mock.mock('POST', /\/a\/\d+/, function(req, res) {
-				return res
-					.status(200)
-					.body(req.url().split('/')[2])
-				;
-			});
+      mock.mock('GET', '/b', function(req, res) {
+        return res
+          .status(200)
+          .body('B')
+        ;
+      });
 
-			var xhr = new XMLHttpRequest();
-			xhr.open('POST', '/a/123');
-			xhr.onload = function() {
-				assert.equal(xhr.responseText, '123');
-				mock.teardown();
-				done();
-			};
-			xhr.send();
-		})
-	});
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', '/a');
+      xhr.onload = function() {
+        assert.equal(xhr.responseText, 'A');
+        mock.teardown();
+        done();
+      };
+      xhr.send();
+    })
+
+    it('should allow registering a handler with URL regexp', function(done) {
+      mock.setup();
+
+      mock.mock('POST', /\/a\/\d+/, function(req, res) {
+        return res
+          .status(200)
+          .body(req.url().split('/')[2])
+        ;
+      });
+
+      var xhr = new XMLHttpRequest();
+      xhr.open('POST', '/a/123');
+      xhr.onload = function() {
+        assert.equal(xhr.responseText, '123');
+        mock.teardown();
+        done();
+      };
+      xhr.send();
+    })
+  });
 
 });


### PR DESCRIPTION
This overlaps with https://github.com/jameslnewell/xhr-mock/pull/16. Please feel free to reject if you find that approach better fitting your goals, or let me know if you want me to update it after merging that PR.

Basically, I've been following two goals:
1) mock requests with unpredictable query params (and decided to implement regexes which are not elegant at all, but universal)
2) have a convenient parsed query to only reply to the requests with specific GET params