### PR TITLE
Make request handling synchronous by default

### DIFF
--- a/lib/MockXMLHttpRequest.js
+++ b/lib/MockXMLHttpRequest.js
@@ -154,52 +154,50 @@ MockXMLHttpRequest.prototype.send = function(data) {
 
   self.readyState = MockXMLHttpRequest.STATE_LOADING;
 
-  self._sendTimeout = setTimeout(function() {
+  var response = MockXMLHttpRequest.handle(new MockRequest(self));
 
-    var response = MockXMLHttpRequest.handle(new MockRequest(self));
+  if (response && response instanceof MockResponse) {
 
-    if (response && response instanceof MockResponse) {
+    var timeout = response.timeout();
 
-      var timeout = response.timeout();
+    if (timeout) {
 
-      if (timeout) {
-
-        //trigger a timeout event because the request timed out - wait for the timeout time because many libs like jquery and superagent use setTimeout to detect the error type
-        self._sendTimeout = setTimeout(function() {
-          self.readyState = MockXMLHttpRequest.STATE_DONE;
-          self.trigger('timeout');
-        }, typeof(timeout) === 'number' ? timeout : self.timeout+1);
-
-      } else {
-
-        //map the response to the XHR object
-        self.status             = response.status();
-        self.statusText         = response.statusText();
-        self._responseHeaders   = response.headers();
-        self.responseType       = 'text';
-        self.response           = response.body();
-        self.responseText       = response.body(); //TODO: detect an object and return JSON, detect XML and return XML
-        self.readyState         = MockXMLHttpRequest.STATE_DONE;
-
-        //trigger a load event because the request was received
-        self.trigger('load');
-
-      }
+      //trigger a timeout event because the request timed out - wait for the timeout time because many libs like jquery and superagent use setTimeout to detect the error type
+      self._sendTimeout = setTimeout(function() {
+        self.readyState = MockXMLHttpRequest.STATE_DONE;
+        self.trigger('timeout');
+      }, typeof(timeout) === 'number' ? timeout : self.timeout+1);
 
     } else {
 
-      //trigger an error because the request was not handled
-      self.readyState = MockXMLHttpRequest.STATE_DONE;
-      self.trigger('error');
+      //map the response to the XHR object
+      self.status             = response.status();
+      self.statusText         = response.statusText();
+      self._responseHeaders   = response.headers();
+      self.responseType       = 'text';
+      self.response           = response.body();
+      self.responseText       = response.body(); //TODO: detect an object and return JSON, detect XML and return XML
+      self.readyState         = MockXMLHttpRequest.STATE_DONE;
+
+      //trigger a load event because the request was received
+      self.trigger('load');
 
     }
 
-  }, 0);
+  } else {
+
+    //trigger an error because the request was not handled
+    self.readyState = MockXMLHttpRequest.STATE_DONE;
+    self.trigger('error');
+
+  }
 
 };
 
 MockXMLHttpRequest.prototype.abort = function() {
-  clearTimeout(this._sendTimeout);
+  if(this._sendTimeout) {
+    clearTimeout(this._sendTimeout);
+  }
 
   if (this.readyState > MockXMLHttpRequest.STATE_UNSENT && this.readyState < MockXMLHttpRequest.STATE_DONE) {
     this.readyState = MockXMLHttpRequest.STATE_UNSENT;

--- a/test/MockXMLHttpRequest.js
+++ b/test/MockXMLHttpRequest.js
@@ -207,7 +207,7 @@ describe('MockXMLHttpRequest', function() {
     it('should allow registering abort event listener', function(done) {
 
       MockXMLHttpRequest.addHandler(function(req, res) {
-        return res
+        return res.timeout(1);
       });
 
       var xhr = new MockXMLHttpRequest();


### PR DESCRIPTION
Thanks for making this library! Very simple and easy to use. However, there is one aspect of it that makes testing a little more difficult than it needs to be. That is the fact that every handler is shunted through a `setTimeout` function. This keeps tests from being able to be written in a synchronous fashion and ended up requiring me to do the following:
```js
it('request sets correct headers', () => {
  const requestSpy = jest.fn((req, res) => res.status(200).body('{}'));
  mock.mock(requestSpy);

  subject();

  return new Promise(resolve => setTimeout(resolve, 0)).then(() => {
    const actual = requestSpy.mock.calls[0][0].headers();
    expect(actual).toEqual({
      accept: 'application/json',
    });
  });
});
```
With the changes in this PR, I can write the same test without the `Promise`/`setTimeout` funny-business:
```js
it('request sets correct headers', () => {
  const requestSpy = jest.fn((req, res) => res.status(200).body('{}'));
  mock.mock(requestSpy);

  subject();

  const actual = requestSpy.mock.calls[0][0].headers();
  expect(actual).toEqual({
    accept: 'application/json',
  });
});
```