### PR TITLE
Guard against missing URLSearchParams

### DIFF
--- a/packages/xhr-mock/src/MockXMLHttpRequest.ts
+++ b/packages/xhr-mock/src/MockXMLHttpRequest.ts
@@ -15,6 +15,7 @@ const notImplementedError = new Error(
 // implemented according to https://xhr.spec.whatwg.org/
 
 const FORBIDDEN_METHODS = ['CONNECT', 'TRACE', 'TRACK'];
+const USE_URL_SEARCH_PARAMS = typeof URLSearchParams !== 'undefined';
 
 export enum ReadyState {
   UNSENT = 0,
@@ -664,7 +665,7 @@ export default class MockXMLHttpRequest extends MockXMLHttpRequestEventTarget
           mimeType = body.type;
         } else if (body instanceof FormData) {
           mimeType = 'multipart/form-data; boundary=----XHRMockFormBoundary';
-        } else if (body instanceof URLSearchParams) {
+        } else if (USE_URL_SEARCH_PARAMS && body instanceof URLSearchParams) {
           encoding = 'UTF-8';
           mimeType = 'application/x-www-form-urlencoded';
         } else if (typeof body === 'string') {


### PR DESCRIPTION
Windows browsers (IE 11 & today's Edge) [don't have](https://caniuse.com/#feat=urlsearchparams) `URLSearchParams`.

![untitled](https://user-images.githubusercontent.com/4426185/37966307-c36cbfa6-31d0-11e8-9e5a-15ab33dfee14.png)
