### PR TITLE
Add sequence util

### DIFF
--- a/packages/xhr-mock/README.md
+++ b/packages/xhr-mock/README.md
@@ -399,6 +399,23 @@ mock.setup();
 mock.post('/', once({status: 201}));
 ```
 
+### send a sequence of responses
+
+In case you need to return a different response each time a request is made, you may use the `sequence` utility.
+
+```js
+import mock, {sequence} from 'xhr-mock';
+
+mock.setup();
+
+mock.post('/', sequence([
+  {status: 200}, // the first request will receive a response with status 200
+  {status: 500}  // the second request will receive a response with status 500
+                 // if a third request is made, no response will be sent
+  ]
+));
+```
+
 ## License
 
 MIT Licensed. Copyright (c) James Newell 2014.

--- a/packages/xhr-mock/src/utils/once.ts
+++ b/packages/xhr-mock/src/utils/once.ts
@@ -1,16 +1,6 @@
 import {MockFunction, MockObject} from '../types';
-import {createResponseFromObject} from '../createResponseFromObject';
+import {sequence} from './sequence';
 
 export function once(mock: MockFunction | MockObject): MockFunction {
-  let callCount = 0;
-  return (req, res) => {
-    if (callCount === 0) {
-      ++callCount;
-      return typeof mock === 'function'
-        ? mock(req, res)
-        : createResponseFromObject(mock);
-    } else {
-      return undefined;
-    }
-  };
+  return sequence([mock]);
 }

--- a/packages/xhr-mock/src/utils/sequence.test.ts
+++ b/packages/xhr-mock/src/utils/sequence.test.ts
@@ -1,0 +1,33 @@
+import MockRequest from '../MockRequest';
+import MockResponse from '../MockResponse';
+import {sequence} from './sequence';
+
+describe('sequence()', () => {
+  it('should return undefined response when inited with empty array ', async () => {
+    const handler = sequence([]);
+    const first = await handler(new MockRequest(), new MockResponse());
+    
+    expect(first).toBeUndefined();
+  });
+
+  it('should return a response when inited with two mocks and called for the first two time', async () => {
+    const handler = sequence([
+      (req, res) => res.status(201).body('Hello'),
+      {status: 201, body: 'World!'}
+    ]);
+    const first = await handler(new MockRequest(), new MockResponse());
+    const second = await handler(new MockRequest(), new MockResponse());
+    const third = await handler(new MockRequest(), new MockResponse());
+    expect(first).toBeInstanceOf(MockResponse);
+    if (first) {
+      expect(first.status()).toEqual(201);
+      expect(first.body()).toEqual('Hello');
+    }
+    expect(second).toBeInstanceOf(MockResponse);
+    if (second) {
+      expect(second.status()).toEqual(201);
+      expect(second.body()).toEqual('World!');
+    }
+    expect(third).toBeUndefined();
+  });
+});

--- a/packages/xhr-mock/src/utils/sequence.ts
+++ b/packages/xhr-mock/src/utils/sequence.ts
@@ -1,0 +1,15 @@
+import {MockFunction, MockObject} from '../types';
+import {createResponseFromObject} from '../createResponseFromObject';
+
+export function sequence(mocks: (MockFunction | MockObject)[]): MockFunction {
+  let callCount = 0;
+
+  return (req, res) => {
+    if (callCount < mocks.length) {
+      const mock = mocks[callCount++];
+      return typeof mock === 'function'
+        ? mock(req, res)
+        : createResponseFromObject(mock);
+    }
+  };
+}


### PR DESCRIPTION
The `once` util is very helpful, and `sequence` is an expansion of the concept.
Instead of creating `twice` and `thrice` etc., use `sequence` to pass an array of any number of responses.

* create `sequence` util
* Add tests for empty array and multiple responses
* add docs to `README.md`