### PR TITLE
Fix import and local declaration name conflict

### DIFF
--- a/packages/xhr-mock/src/types.ts
+++ b/packages/xhr-mock/src/types.ts
@@ -2,9 +2,7 @@ import {MockHeaders} from './MockHeaders';
 import MockRequest from './MockRequest';
 import MockResponse from './MockResponse';
 
-export type MockHeaders = {
-  [name: string]: string;
-};
+export {MockHeaders};
 
 export type MockObject = {
   status?: number;


### PR DESCRIPTION
Fix `Import declaration conflicts with local declaration of 'MockHeaders'` error in TS 3.7.