### PR TITLE
fix types export to support typescript 3.7

### DIFF
--- a/packages/xhr-mock/src/types.ts
+++ b/packages/xhr-mock/src/types.ts
@@ -2,9 +2,7 @@ import {MockHeaders} from './MockHeaders';
 import MockRequest from './MockRequest';
 import MockResponse from './MockResponse';
 
-export type MockHeaders = {
-  [name: string]: string;
-};
+export type MockHeaders = MockHeaders;
 
 export type MockObject = {
   status?: number;

--- a/packages/xhr-mock/src/types.ts
+++ b/packages/xhr-mock/src/types.ts
@@ -1,8 +1,7 @@
 import {MockHeaders} from './MockHeaders';
+export {MockHeaders} from './MockHeaders';
 import MockRequest from './MockRequest';
 import MockResponse from './MockResponse';
-
-export type MockHeaders = MockHeaders;
 
 export type MockObject = {
   status?: number;


### PR DESCRIPTION
**The Problem:**
Typescript 3.7 (released yesterday)  introduced a breaking change, and compiling `xhr-mock` with the new version now fails.

https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#local-and-imported-type-declarations-now-conflict

It is now illegal to redeclare an imported type.

This already started breaking the build of some users.

**The Fix:** 
instead of re-declaring `MockHeaders` type, simply re-export it.
This does not affect anything else, since the types are identical.