### PR TITLE
responseType=blob + string support

### DIFF
--- a/packages/xhr-mock-tests/package.json
+++ b/packages/xhr-mock-tests/package.json
@@ -2,13 +2,14 @@
   "name": "xhr-mock-tests",
   "private": true,
   "dependencies": {
-    "@types/url-search-params": "^0.10.1",
+    "@types/url-search-params": "^1.1.0",
     "axios": "^0.19.0",
     "core-js": "^2.5.3",
     "jquery": "^3.2.1",
     "rxjs": "^5.5.6",
     "superagent": "^3.8.2",
     "url-search-params": "^0.10.0",
+    "whatwg-fetch": "^3.4.1",
     "xhr-mock": "^2.5.1"
   },
   "devDependencies": {
@@ -22,7 +23,7 @@
     "testem": "^1.18.4",
     "ts-loader": "^3.2.0",
     "tslint": "^5.9.1",
-    "typescript": "2.7.2",
+    "typescript": "^4.0.5",
     "webpack": "^3.10.0"
   },
   "scripts": {

--- a/packages/xhr-mock-tests/src/whatwg-fetch.test.ts
+++ b/packages/xhr-mock-tests/src/whatwg-fetch.test.ts
@@ -1,0 +1,121 @@
+import {expect} from 'chai';
+window.fetch = null as any;
+import mock from 'xhr-mock';
+import 'whatwg-fetch';
+
+describe('whatwg-fetch', () => {
+  beforeEach(() => mock.setup());
+  afterEach(() => mock.teardown());
+
+  it('should GET', async () => {
+    mock.use((req, res) => {
+      expect(req.method()).to.eq('GET');
+      expect(String(req.url())).to.eq('/');
+      expect(req.body()).to.eq(null);
+      return res
+        .status(200)
+        .reason('OK')
+        .header('Content-Length', '12')
+        .body('Hello World!');
+    });
+
+    const res = await fetch('/');
+
+    expect(res.status).to.eq(200);
+    expect(res.statusText).to.eq('OK');
+    expect(res.headers.get('content-length')).to.eq('12');
+    const data = await res.text();
+    expect(data).to.eq('Hello World!');
+  });
+
+  it('should POST', async () => {
+    mock.use((req, res) => {
+      expect(req.method()).to.eq('POST');
+      expect(String(req.url())).to.eq('/');
+      expect(req.body()).to.eq(JSON.stringify({foo: 'bar'}));
+      return res
+        .status(201)
+        .reason('Created')
+        .header('Content-Length', '12')
+        .body('Hello World!');
+    });
+
+    const res = await fetch('/', {
+      method: 'POST',
+      body: JSON.stringify({foo: 'bar'})
+    });
+
+    expect(res.status).to.eq(201);
+    expect(res.statusText).to.eq('Created');
+    expect(res.headers.get('content-length')).to.eq('12');
+    const data = await res.text();
+    expect(data).to.eq('Hello World!');
+  });
+
+  it('should PUT', async () => {
+    mock.use((req, res) => {
+      expect(req.method()).to.eq('PUT');
+      expect(String(req.url())).to.eq('/');
+      expect(req.body()).to.eq(JSON.stringify({foo: 'bar'}));
+      return res
+        .status(200)
+        .reason('Created')
+        .header('Content-Length', '12')
+        .body('Hello World!');
+    });
+
+    const res = await fetch('/', {
+      method: 'PUT',
+      body: JSON.stringify({foo: 'bar'})
+    });
+
+    expect(res.status).to.eq(200);
+    expect(res.statusText).to.eq('Created');
+    expect(res.headers.get('content-length')).to.eq('12');
+    const data = await res.text();
+    expect(data).to.eq('Hello World!');
+  });
+
+  it('should DELETE', async () => {
+    mock.use((req, res) => {
+      expect(req.method()).to.eq('DELETE');
+      expect(String(req.url())).to.eq('/');
+      expect(req.body()).to.eq(null);
+      return res.status(204).reason('No Content');
+    });
+
+    const res = await fetch('/', {method: 'DELETE'});
+
+    expect(res.status).to.eq(204);
+    expect(res.statusText).to.eq('No Content');
+    expect(res.headers.has('content-length')).to.be.false;
+    const data = await res.text();
+    expect(data).to.eq('');
+  });
+
+  it('should abort', async () => {
+    mock.get('/', () => new Promise(() => {}));
+
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 10);
+
+    try {
+      await fetch('/', {signal: controller.signal});
+      expect.fail();
+    } catch (error) {
+      expect(error.message.toLowerCase()).to.contain('aborted');
+    }
+  });
+
+  it('should error', async () => {
+    mock.get('/', () => Promise.reject(new Error('😬')));
+
+    try {
+      await fetch('/');
+      expect.fail();
+    } catch (error) {
+      expect(error).to.be.an('Error');
+      expect(error.message).to.contain('Network request failed');
+    }
+  });
+});

--- a/packages/xhr-mock/package.json
+++ b/packages/xhr-mock/package.json
@@ -40,7 +40,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "ts-jest": "^22.0.1",
     "tslint": "^5.9.1",
-    "typescript": "2.7.2"
+    "typescript": "^4.0.5"
   },
   "scripts": {
     "clean": "rm -rf ./lib ./dist",

--- a/packages/xhr-mock/src/MockEvent.ts
+++ b/packages/xhr-mock/src/MockEvent.ts
@@ -12,12 +12,14 @@ export default class MockEvent implements Event {
   readonly timeStamp: number;
   readonly type: string;
   readonly scoped: boolean;
+  readonly composed: boolean;
 
   readonly AT_TARGET: number;
   readonly BUBBLING_PHASE: number;
   readonly CAPTURING_PHASE: number;
+  readonly NONE: number;
 
-  constructor(type: string, eventInitDict?: EventInit) {
+  constructor(type: string, eventInitDict?: EventInit & {scoped?: boolean}) {
     this.type = type || '';
     if (eventInitDict) {
       const {
@@ -53,5 +55,9 @@ export default class MockEvent implements Event {
 
   deepPath(): EventTarget[] {
     throw new Error();
+  }
+
+  composedPath(): EventTarget[] {
+    throw new Error('Method not implemented.');
   }
 }

--- a/packages/xhr-mock/src/MockEventTarget.ts
+++ b/packages/xhr-mock/src/MockEventTarget.ts
@@ -7,7 +7,7 @@ export default class MockEventTarget implements EventTarget {
 
   addEventListener(
     type: string,
-    listener?: EventListenerOrEventListenerObject,
+    listener: EventListenerOrEventListenerObject,
     options?: boolean | AddEventListenerOptions
   ): void {
     this.listeners = this.listeners || {};
@@ -28,7 +28,7 @@ export default class MockEventTarget implements EventTarget {
 
   removeEventListener(
     type: string,
-    listener?: EventListenerOrEventListenerObject,
+    listener: EventListenerOrEventListenerObject,
     options?: boolean | EventListenerOptions
   ): void {
     this.listeners = this.listeners || {};

--- a/packages/xhr-mock/src/MockXMLHttpRequest.test.ts
+++ b/packages/xhr-mock/src/MockXMLHttpRequest.test.ts
@@ -3,6 +3,7 @@ import MockProgressEvent from './MockProgressEvent';
 import MockXMLHttpRequest from './MockXMLHttpRequest';
 import {MockRequest} from '.';
 import {MockError} from './MockError';
+import {isExportDeclaration} from 'typescript';
 
 function failOnEvent(done: jest.DoneCallback) {
   return function(event: MockProgressEvent) {
@@ -104,6 +105,44 @@ describe('MockXMLHttpRequest', () => {
       xhr.onerror = failOnEvent(done);
       xhr.open('get', '/');
       xhr.send();
+    });
+
+    it('should return null when type is blob and the request is not done', () => {
+      MockXMLHttpRequest.addHandler((req, res) => res.body('Hello Blob!'));
+      const xhr = new MockXMLHttpRequest();
+      xhr.responseType = 'blob';
+      xhr.open('get', '/');
+      expect(xhr.response).toEqual(null);
+    });
+
+    it('should return blob when type is blob, body is string, and the request is done', done => {
+      MockXMLHttpRequest.addHandler((req, res) => res.body('Hello Blob!'));
+      const xhr = new MockXMLHttpRequest();
+      xhr.responseType = 'blob';
+      xhr.open('get', '/');
+      xhr.send();
+      const blobAsText = (blob: Blob) =>
+        new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = e => resolve(e.target && e.target.result);
+          reader.onerror = reject;
+          reader.readAsText(blob);
+        });
+
+      xhr.onload = () => {
+        try {
+          expect(xhr.response).toBeInstanceOf(Blob);
+          expect(xhr.response.type).toEqual('text/plain');
+          blobAsText(xhr.response)
+            .then(text => {
+              expect(text).toEqual('Hello Blob!');
+              done();
+            })
+            .catch(done.fail);
+        } catch (error) {
+          done.fail(error);
+        }
+      };
     });
 
     it('should return null when the type is other and the request is not done', () => {

--- a/packages/xhr-mock/src/MockXMLHttpRequest.ts
+++ b/packages/xhr-mock/src/MockXMLHttpRequest.ts
@@ -162,7 +162,7 @@ export default class MockXMLHttpRequest extends MockXMLHttpRequestEventTarget
 
     if (this.responseType === 'blob' && typeof body === 'string') {
       try {
-        throw notImplementedError;
+        return new Blob([body], {type: 'text/plain'});
       } catch (error) {
         return null;
       }

--- a/packages/xhr-mock/src/proxy.browser.ts
+++ b/packages/xhr-mock/src/proxy.browser.ts
@@ -22,7 +22,8 @@ export default function(
     const xhr: XMLHttpRequest = new XHRMock.RealXMLHttpRequest();
 
     // TODO: reject with the correct type of error
-    xhr.onerror = event => reject(event.error);
+    xhr.onerror = (event: ProgressEvent<EventTarget> & {error?: any}) =>
+      reject(event.error);
 
     xhr.onloadend = () => {
       res

--- a/packages/xhr-mock/src/proxy.test.ts
+++ b/packages/xhr-mock/src/proxy.test.ts
@@ -66,7 +66,7 @@ describe('proxy', () => {
     const body = res.body() || '';
     expect(JSON.parse(body)).toEqual(
       expect.objectContaining({
-        url: 'https://httpbin.org/put',
+        url: 'http://httpbin.org/put',
         headers: expect.objectContaining({
           Foo: 'bar',
           Bar: 'foo'
@@ -104,7 +104,7 @@ describe('proxy', () => {
 
     req
       .method('PUT')
-      .url('http://httpbin.org/put')
+      .url('https://httpbin.org/put')
       .header('Content-Length', '12')
       .body('Hello World!');
     await proxy(req, res);
@@ -128,7 +128,7 @@ describe('proxy', () => {
     const body = res.body() || '';
     expect(JSON.parse(body)).toEqual(
       expect.objectContaining({
-        url: 'https://httpbin.org/put',
+        url: 'http://httpbin.org/put',
         data: ''
       })
     );

--- a/packages/xhr-mock/test/integration.test.ts
+++ b/packages/xhr-mock/test/integration.test.ts
@@ -107,11 +107,13 @@ describe('integration', () => {
     expect(ret1).toEqual('Hello World!');
 
     const ret2 = await request('GET', 'https://reqres.in/api/users/2');
-    expect(JSON.parse(ret2)).toEqual({
-      data: expect.objectContaining({
-        id: 2,
-        first_name: 'Janet'
+    expect(JSON.parse(ret2)).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          id: 2,
+          first_name: 'Janet'
+        })
       })
-    });
+    );
   });
 });


### PR DESCRIPTION
In order to support the `whatwg-fetch` polyfill which sets
`responseType='blob'` for every request, create a new Blob
when the responseType is `blob` and the body is a string.

Added integration tests for `whatwg-fetch`

Fixed proxy tests that are failing because the remote services response
have changed. `reqres.in` and `httpbin.com` have changed their behavior.
Fix those for a working test suite again.

Typescript definitions needed some updates in order to pass. Upgraded
Typescript to 4.0.