### PR TITLE
fix: fix error when yarn run build:cjs

### DIFF
--- a/packages/xhr-mock/package.json
+++ b/packages/xhr-mock/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@alexlur/rollup-plugin-typescript": "^1.0.4",
     "@types/jest": "22.2.0",
-    "@types/node": "^9.3.0",
+    "@types/node": "9.4.0",
     "axios": "^0.19.0",
     "jest": "^22.0.5",
     "rollup": "^0.53.3",


### PR DESCRIPTION
fix the error when use `yarn run build:cjs`

error detail: 
node_modules/@types/node/index.d.ts:39:1 - error TS1084: Invalid 'reference' directive syntax.
